### PR TITLE
feat: Add rewards system with unit tests for Issue #9

### DIFF
--- a/swaptrade-contracts/counter/portfolio.rs
+++ b/swaptrade-contracts/counter/portfolio.rs
@@ -7,12 +7,19 @@ pub enum Asset {
     Custom(Symbol),
 }
 
+#[derive(Clone, PartialEq, Debug)]
+#[contracttype]
+pub enum Badge {
+    FirstTrade,
+}
+
 #[derive(Clone)]
 #[contracttype]
 pub struct Portfolio {
     balances: Map<(Address, Asset), i128>,
     trades: Map<Address, u32>,       // number of trades per user
     pnl: Map<Address, i128>,         // cumulative balance change placeholder
+    badges: Map<(Address, Badge), bool>, // tracks which badges each user has earned
 }
 
 impl Portfolio {
@@ -21,6 +28,7 @@ impl Portfolio {
             balances: Map::new(),
             trades: Map::new(),
             pnl: Map::new(),
+            badges: Map::new(),
         }
     }
 
@@ -40,9 +48,48 @@ impl Portfolio {
     }
 
     /// Record a swap execution (increase trade count).
+    /// Automatically awards "First Trade" badge if this is the user's first trade.
     pub fn record_trade(&mut self, env: &Env, user: Address) {
         let count = self.trades.get(env, &user).unwrap_or(0);
         self.trades.set(env, &user, &(count + 1));
+
+        // Award "First Trade" badge if this is the first trade
+        if count == 0 {
+            self.award_badge(env, user, Badge::FirstTrade);
+        }
+    }
+
+    /// Award a badge to a user if they don't already have it.
+    /// Returns true if badge was awarded, false if user already had it.
+    pub fn award_badge(&mut self, env: &Env, user: Address, badge: Badge) -> bool {
+        let key = (user, badge);
+
+        // Check if user already has this badge
+        if self.has_badge(env, key.0.clone(), key.1.clone()) {
+            return false; // Badge already awarded, prevent duplicate
+        }
+
+        // Award the badge
+        self.badges.set(env, &key, &true);
+        true
+    }
+
+    /// Check if a user has earned a specific badge.
+    pub fn has_badge(&self, env: &Env, user: Address, badge: Badge) -> bool {
+        let key = (user, badge);
+        self.badges.get(env, &key).unwrap_or(false)
+    }
+
+    /// Get all badges earned by a user.
+    pub fn get_user_badges(&self, env: &Env, user: Address) -> Vec<Badge> {
+        let mut badges = Vec::new(env);
+
+        // Check for FirstTrade badge
+        if self.has_badge(env, user.clone(), Badge::FirstTrade) {
+            badges.push_back(Badge::FirstTrade);
+        }
+
+        badges
     }
 
     /// Get balance of a token for a given user.
@@ -50,6 +97,14 @@ impl Portfolio {
     pub fn balance_of(&self, env: &Env, token: Asset, user: Address) -> i128 {
         let key = (user, token);
         self.balances.get(env, &key).unwrap_or(0)
+    }
+
+    /// Get portfolio statistics for a user
+    /// Returns (trade_count, pnl)
+    pub fn get_portfolio(&self, env: &Env, user: Address) -> (u32, i128) {
+        let trades = self.trades.get(env, &user).unwrap_or(0);
+        let pnl = self.pnl.get(env, &user).unwrap_or(0);
+        (trades, pnl)
     }
 }
 
@@ -135,4 +190,139 @@ fn test_balance_of_isolates_different_users() {
     // user1 should have balance, user2 should have 0
     assert_eq!(portfolio.balance_of(&env, Asset::XLM, user1), 1000);
     assert_eq!(portfolio.balance_of(&env, Asset::XLM, user2), 0);
+}
+
+// ===== REWARDS TESTS =====
+
+/// Test that the "First Trade" badge is awarded when a user completes their first trade
+#[test]
+fn test_award_first_trade_badge() {
+    let env = Env::default();
+    let mut portfolio = Portfolio::new();
+    let user = Address::generate(&env);
+
+    // User should not have any badges initially
+    let badges_before = portfolio.get_user_badges(&env, user.clone());
+    assert_eq!(badges_before.len(), 0);
+
+    // User should not have FirstTrade badge
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), false);
+
+    // Record the user's first trade
+    portfolio.record_trade(&env, user.clone());
+
+    // User should now have the FirstTrade badge
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), true);
+
+    // Verify badge appears in user's badge list
+    let badges_after = portfolio.get_user_badges(&env, user);
+    assert_eq!(badges_after.len(), 1);
+}
+
+/// Test that the "First Trade" badge is only awarded once (no duplicates)
+#[test]
+fn test_prevent_duplicate_badge_assignment() {
+    let env = Env::default();
+    let mut portfolio = Portfolio::new();
+    let user = Address::generate(&env);
+
+    // Record first trade - should award badge
+    portfolio.record_trade(&env, user.clone());
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), true);
+    let badges_after_first = portfolio.get_user_badges(&env, user.clone());
+    assert_eq!(badges_after_first.len(), 1);
+
+    // Record second trade - should NOT duplicate the badge
+    portfolio.record_trade(&env, user.clone());
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), true);
+    let badges_after_second = portfolio.get_user_badges(&env, user.clone());
+    assert_eq!(badges_after_second.len(), 1); // Still only 1 badge
+
+    // Record third trade - should still NOT duplicate the badge
+    portfolio.record_trade(&env, user.clone());
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), true);
+    let badges_after_third = portfolio.get_user_badges(&env, user);
+    assert_eq!(badges_after_third.len(), 1); // Still only 1 badge
+}
+
+/// Test that different users receive badges independently
+#[test]
+fn test_badges_are_user_specific() {
+    let env = Env::default();
+    let mut portfolio = Portfolio::new();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    // User1 completes a trade
+    portfolio.record_trade(&env, user1.clone());
+    assert_eq!(portfolio.has_badge(&env, user1.clone(), Badge::FirstTrade), true);
+    assert_eq!(portfolio.has_badge(&env, user2.clone(), Badge::FirstTrade), false);
+
+    // User2 completes a trade
+    portfolio.record_trade(&env, user2.clone());
+    assert_eq!(portfolio.has_badge(&env, user1.clone(), Badge::FirstTrade), true);
+    assert_eq!(portfolio.has_badge(&env, user2.clone(), Badge::FirstTrade), true);
+
+    // Both users should have exactly 1 badge each
+    assert_eq!(portfolio.get_user_badges(&env, user1).len(), 1);
+    assert_eq!(portfolio.get_user_badges(&env, user2).len(), 1);
+}
+
+/// Test that badge state persists correctly
+#[test]
+fn test_badge_persistence() {
+    let env = Env::default();
+    let mut portfolio = Portfolio::new();
+    let user = Address::generate(&env);
+
+    // Award badge via trade
+    portfolio.record_trade(&env, user.clone());
+
+    // Check multiple times - should always return true
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), true);
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), true);
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), true);
+
+    // Badge count should remain consistent
+    assert_eq!(portfolio.get_user_badges(&env, user).len(), 1);
+}
+
+/// Test that new users start with no badges
+#[test]
+fn test_new_user_has_no_badges() {
+    let env = Env::default();
+    let portfolio = Portfolio::new();
+    let user = Address::generate(&env);
+
+    // New user should have no badges
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), false);
+    assert_eq!(portfolio.get_user_badges(&env, user).len(), 0);
+}
+
+/// Test reward logic integration with trade counting
+#[test]
+fn test_rewards_integrate_with_trade_counting() {
+    let env = Env::default();
+    let mut portfolio = Portfolio::new();
+    let user = Address::generate(&env);
+
+    // Get initial portfolio stats
+    let (trades_before, _) = portfolio.get_portfolio(&env, user.clone());
+    assert_eq!(trades_before, 0);
+
+    // Record first trade
+    portfolio.record_trade(&env, user.clone());
+    let (trades_after_first, _) = portfolio.get_portfolio(&env, user.clone());
+    assert_eq!(trades_after_first, 1);
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), true);
+
+    // Record additional trades
+    portfolio.record_trade(&env, user.clone());
+    portfolio.record_trade(&env, user.clone());
+    let (trades_after_multiple, _) = portfolio.get_portfolio(&env, user.clone());
+    assert_eq!(trades_after_multiple, 3);
+
+    // Badge should still be there, but not duplicated
+    assert_eq!(portfolio.has_badge(&env, user.clone(), Badge::FirstTrade), true);
+    assert_eq!(portfolio.get_user_badges(&env, user).len(), 1);
 }


### PR DESCRIPTION
Implemented a comprehensive rewards/badges system for the SwapTrade contract:

## Changes:
- Added Badge enum to track user achievements (FirstTrade badge)
- Extended Portfolio struct with badges Map for tracking user achievements
- Implemented reward methods:
  - award_badge(): Awards badges and prevents duplicates
  - has_badge(): Checks if user has a specific badge
  - get_user_badges(): Retrieves all badges for a user
- Auto-awards FirstTrade badge on user's first trade via record_trade()
- Added get_portfolio() method for retrieving user stats
- Exported Badge type in CounterContract

## Tests (portfolio.rs):
✓ test_award_first_trade_badge - Verifies badge awarded on first trade ✓ test_prevent_duplicate_badge_assignment - Ensures no duplicate badges ✓ test_badges_are_user_specific - Confirms user isolation ✓ test_badge_persistence - Validates badge state persistence ✓ test_new_user_has_no_badges - Tests initial state ✓ test_rewards_integrate_with_trade_counting - Integration test

All tests follow Soroban best practices and use the testutils framework.

closes #9 