### PR TITLE
Add Token Swap via Simplified AMM

### DIFF
--- a/swaptrade-contracts/counter/src/lib.rs
+++ b/swaptrade-contracts/counter/src/lib.rs
@@ -1,30 +1,116 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};
 
-const COUNTER: Symbol = symbol_short!("COUNTER");
+// Bring in modules from parent directory
+mod portfolio { include!("../portfolio.rs"); }
+mod trading { include!("../trading.rs"); }
+
+use portfolio::{Portfolio, Asset};
+pub use portfolio::Badge;
+use trading::perform_swap;
 
 #[contract]
-pub struct SwapTradeContract;
+pub struct CounterContract;
 
 #[contractimpl]
-impl SwapTradeContract {
-    /// Initialize the contract
-    pub fn init(env: Env) -> u32 {
-        env.storage().instance().set(&COUNTER, &0u32);
-        0
+impl CounterContract {
+    pub fn mint(env: Env, token: Symbol, to: Address, amount: i128) {
+        let mut portfolio: Portfolio = env
+            .storage()
+            .instance()
+            .get()
+            .unwrap_or_else(Portfolio::new);
+
+        let asset = match token.to_string().as_str() {
+            "XLM" => Asset::XLM,
+            _ => Asset::Custom(token.clone()),
+        };
+
+        portfolio.mint(&env, asset, to, amount);
+
+        env.storage().instance().set(&portfolio);
     }
 
-    /// Increment the counter
-    pub fn increment(env: Env) -> u32 {
-        let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0);
-        count += 1;
-        env.storage().instance().set(&COUNTER, &count);
-        count
+    pub fn balance_of(env: Env, token: Symbol, user: Address) -> i128 {
+        let portfolio: Portfolio = env
+            .storage()
+            .instance()
+            .get()
+            .unwrap_or_else(Portfolio::new);
+
+        let asset = match token.to_string().as_str() {
+            "XLM" => Asset::XLM,
+            _ => Asset::Custom(token.clone()),
+        };
+
+        portfolio.balance_of(&env, asset, user)
     }
 
-    /// Get the current count
-    pub fn get_count(env: Env) -> u32 {
-        env.storage().instance().get(&COUNTER).unwrap_or(0)
+    /// Alias to match external API
+    pub fn get_balance(env: Env, token: Symbol, owner: Address) -> i128 {
+        Self::balance_of(env, token, owner)
+    }
+
+    /// Swap tokens using simplified AMM (1:1 XLM <-> USDC-SIM)
+    pub fn swap(env: Env, from: Symbol, to: Symbol, amount: i128, user: Address) -> i128 {
+        let mut portfolio: Portfolio = env
+            .storage()
+            .instance()
+            .get()
+            .unwrap_or_else(Portfolio::new);
+
+        let out_amount = perform_swap(&env, &mut portfolio, from, to, amount, user.clone());
+
+        portfolio.record_trade(&env, user);
+        env.storage().instance().set(&portfolio);
+
+        out_amount
+    }
+
+    /// Record a swap execution for a user
+    pub fn record_trade(env: Env, user: Address) {
+        let mut portfolio: Portfolio = env
+            .storage()
+            .instance()
+            .get()
+            .unwrap_or_else(Portfolio::new);
+
+        portfolio.record_trade(&env, user);
+
+        env.storage().instance().set(&portfolio);
+    }
+
+    /// Get portfolio stats for a user (trade count, pnl)
+    pub fn get_portfolio(env: Env, user: Address) -> (u32, i128) {
+        let portfolio: Portfolio = env
+            .storage()
+            .instance()
+            .get()
+            .unwrap_or_else(Portfolio::new);
+
+        portfolio.get_portfolio(&env, user)
+    }
+
+    /// Check if a user has earned a specific badge
+    pub fn has_badge(env: Env, user: Address, badge: Badge) -> bool {
+        let portfolio: Portfolio = env
+            .storage()
+            .instance()
+            .get()
+            .unwrap_or_else(Portfolio::new);
+
+        portfolio.has_badge(&env, user, badge)
+    }
+
+    /// Get all badges earned by a user
+    pub fn get_user_badges(env: Env, user: Address) -> Vec<Badge> {
+        let portfolio: Portfolio = env
+            .storage()
+            .instance()
+            .get()
+            .unwrap_or_else(Portfolio::new);
+
+        portfolio.get_user_badges(&env, user)
     }
 }
 

--- a/swaptrade-contracts/counter/trading.rs
+++ b/swaptrade-contracts/counter/trading.rs
@@ -1,0 +1,39 @@
+use soroban_sdk::{Env, Symbol, Address};
+
+use crate::portfolio::{Portfolio, Asset};
+
+fn symbol_to_asset(sym: &Symbol) -> Option<Asset> {
+    let s = sym.to_string();
+    match s.as_str() {
+        "XLM" => Some(Asset::XLM),
+        "USDC-SIM" => Some(Asset::Custom(sym.clone())),
+        _ => None,
+    }
+}
+
+/// Performs a simplified 1:1 swap between XLM and USDC-SIM for a user.
+/// Returns the amount received.
+pub fn perform_swap(
+    env: &Env,
+    portfolio: &mut Portfolio,
+    from: Symbol,
+    to: Symbol,
+    amount: i128,
+    user: Address,
+) -> i128 {
+    assert!(amount > 0, "Amount must be positive");
+
+    // Validate tokens and disallow identical pairs
+    assert!(from != to, "Tokens must be different");
+
+    let from_asset = symbol_to_asset(&from).expect("Invalid from token");
+    let to_asset = symbol_to_asset(&to).expect("Invalid to token");
+
+    // Simplified AMM: 1:1 rate between XLM and USDC-SIM
+    let out_amount = amount;
+
+    // Debit from 'from_asset' and credit to 'to_asset'
+    portfolio.transfer_asset(env, from_asset, to_asset, user, amount);
+
+    out_amount
+}


### PR DESCRIPTION
### Add Token Swap via Simplified AMM

**Goal:**
Introduce support for token swaps between **XLM** and **USDC-SIM** using a lightweight AMM model, enabling users to trade directly within the contract.

**Scope / Changes:**

* Created new module `trading.rs`.
* Implemented `swap(from: Symbol, to: Symbol, amount: i128, user: Address)` function.
* Logic:

  * Deducts `amount` from `user` balance in `from` token.
  * Credits equivalent balance in `to` token.
  * Rejects invalid tokens and insufficient funds.
* Added error handling for invalid swaps.
* Wrote tests covering valid swaps, insufficient balance, and invalid tokens.

**Acceptance Criteria:**

* ✅ User with sufficient balance can successfully swap.
* ✅ Balances are updated correctly after swap.
* ✅ Invalid inputs (wrong token, insufficient balance) result in errors.
* ✅ Contract compiles and passes all tests.

closes #5 