### PR TITLE
fix: resolve security and logic bugs (#186 #187 #188 #189)

### DIFF
--- a/swaptrade-contracts/counter/src/lib.rs
+++ b/swaptrade-contracts/counter/src/lib.rs
@@ -174,21 +174,23 @@ fn require_authenticated_verified_user(env: &Env, user: &Address) -> Result<(), 
     require_verified_user(env, user)
 }
 
-pub fn pause_trading(env: Env) -> Result<bool, SwapTradeError> {
-    // NOTE: Authentication check (invoker) removed for compatibility with SDK versions
-    // In production ensure proper auth by checking invoker and require_admin.
+pub fn pause_trading(env: Env, caller: Address) -> Result<bool, SwapTradeError> {
+    caller.require_auth();
+    crate::admin::require_admin(&env, &caller)?;
     env.storage().persistent().set(&PAUSED_KEY, &true);
     Ok(true)
 }
 
-pub fn resume_trading(env: Env) -> Result<bool, SwapTradeError> {
-    // NOTE: Authentication check (invoker) removed for compatibility with SDK versions
+pub fn resume_trading(env: Env, caller: Address) -> Result<bool, SwapTradeError> {
+    caller.require_auth();
+    crate::admin::require_admin(&env, &caller)?;
     env.storage().persistent().set(&PAUSED_KEY, &false);
     Ok(true)
 }
 
-pub fn set_admin(env: Env, new_admin: Address) -> Result<(), SwapTradeError> {
-    // NOTE: Authentication check (invoker) removed for compatibility with SDK versions
+pub fn set_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), SwapTradeError> {
+    caller.require_auth();
+    crate::admin::require_admin(&env, &caller)?;
     env.storage().persistent().set(&ADMIN_KEY, &new_admin);
     Ok(())
 }
@@ -673,6 +675,12 @@ impl CounterContract {
 
         let user_tier = portfolio.get_user_tier(&env, user.clone());
         RateLimiter::get_lp_status(&env, &user, &user_tier)
+    }
+
+    /// Remove expired rate limit counters for a user.
+    /// Returns the number of storage entries cleaned up.
+    pub fn cleanup_rate_limits(env: Env, user: Address) -> u32 {
+        RateLimiter::cleanup_rate_limits(&env, &user)
     }
 
     // ===== BATCH OPERATIONS =====

--- a/swaptrade-contracts/counter/src/liquidity_pool.rs
+++ b/swaptrade-contracts/counter/src/liquidity_pool.rs
@@ -1,6 +1,10 @@
 use crate::errors::ContractError;
 use soroban_sdk::{contracttype, Address, Env, Map, Symbol, Vec};
 
+/// Minimum LP tokens that must be minted per add_liquidity call.
+/// Prevents dust/rounding attacks by ensuring each deposit is economically meaningful.
+const MIN_LP_TOKENS: i128 = 1000;
+
 #[derive(Clone, Debug, PartialEq)]
 #[contracttype]
 pub struct LiquidityPool {
@@ -139,7 +143,7 @@ impl PoolRegistry {
             (lp_a.min(lp_b)) as i128
         };
 
-        if lp_tokens <= 0 {
+        if lp_tokens <= 0 || lp_tokens < MIN_LP_TOKENS {
             return Err(ContractError::InvalidAmount);
         }
 

--- a/swaptrade-contracts/counter/src/rate_limit.rs
+++ b/swaptrade-contracts/counter/src/rate_limit.rs
@@ -304,6 +304,43 @@ impl RateLimiter {
             cooldown_ms: window.cooldown_ms(timestamp),
         }
     }
+
+    /// Remove expired rate limit counters for a user.
+    ///
+    /// Cleans up swap and LP counters whose time windows have already passed,
+    /// preventing unbounded storage growth.  Only windows strictly older than
+    /// the current window are removed; the active window is left intact.
+    ///
+    /// Returns the number of storage entries removed.
+    pub fn cleanup_rate_limits(env: &Env, user: &Address) -> u32 {
+        let timestamp = env.ledger().timestamp();
+        let current_hourly = TimeWindow::hourly(timestamp).window_start;
+        let current_daily = TimeWindow::daily(timestamp).window_start;
+
+        let mut removed = 0u32;
+
+        // Attempt to remove the previous hourly window (one window back)
+        if current_hourly >= 3600 {
+            let prev_hourly = current_hourly - 3600;
+            let swap_key = (user.clone(), symbol_short!("swap"), prev_hourly);
+            if env.storage().persistent().has(&swap_key) {
+                env.storage().persistent().remove(&swap_key);
+                removed += 1;
+            }
+        }
+
+        // Attempt to remove the previous daily window (one window back)
+        if current_daily >= 86400 {
+            let prev_daily = current_daily - 86400;
+            let lp_key = (user.clone(), symbol_short!("lp_op"), prev_daily);
+            if env.storage().persistent().has(&lp_key) {
+                env.storage().persistent().remove(&lp_key);
+                removed += 1;
+            }
+        }
+
+        removed
+    }
 }
 
 #[cfg(all(test, feature = "experimental"))]

--- a/swaptrade-contracts/counter/src/staking_bonus.rs
+++ b/swaptrade-contracts/counter/src/staking_bonus.rs
@@ -105,6 +105,8 @@ pub enum StakingBonusKey {
     TotalStaked,
     /// Total bonuses distributed
     TotalBonusesDistributed,
+    /// Registry of all staker addresses (for distribution iteration)
+    StakerRegistry,
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -190,6 +192,20 @@ impl StakingBonusManager {
             .unwrap_or_else(|| Vec::new(env));
 
         let stake_id = stakes.len() as u32;
+
+        // Register staker if this is their first stake
+        if stake_id == 0 {
+            let mut registry: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&StakingBonusKey::StakerRegistry)
+                .unwrap_or_else(|| Vec::new(env));
+            registry.push_back(user.clone());
+            env.storage()
+                .persistent()
+                .set(&StakingBonusKey::StakerRegistry, &registry);
+        }
+
         stakes.push_back(stake.clone());
 
         // Update storage
@@ -481,6 +497,45 @@ impl StakingBonusManager {
 
         let mut total_distributed = 0i128;
         let mut recipient_count = 0u32;
+
+        // Collect all staker addresses that have active stakes
+        // We iterate over known stakers by scanning UserStakes keys.
+        // Since Soroban storage doesn't support key enumeration, we maintain
+        // a staker registry under a dedicated key.
+        let stakers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StakingBonusKey::StakerRegistry)
+            .unwrap_or_else(|| Vec::new(env));
+
+        for staker in stakers.iter() {
+            let stakes: Vec<StakeRecord> = env
+                .storage()
+                .persistent()
+                .get(&StakingBonusKey::UserStakes(staker.clone()))
+                .unwrap_or_else(|| Vec::new(env));
+
+            let mut user_bonus = 0i128;
+            for stake in stakes.iter() {
+                if stake.is_active && !stake.bonus_claimed {
+                    user_bonus += stake.bonus_amount;
+                }
+            }
+
+            if user_bonus > 0 {
+                let prev_earned: i128 = env
+                    .storage()
+                    .persistent()
+                    .get(&StakingBonusKey::UserEarnedBonuses(staker.clone()))
+                    .unwrap_or(0);
+                env.storage().persistent().set(
+                    &StakingBonusKey::UserEarnedBonuses(staker.clone()),
+                    &(prev_earned + user_bonus),
+                );
+                total_distributed += user_bonus;
+                recipient_count += 1;
+            }
+        }
 
         // Get all distribution records
         let mut distributions: Vec<DistributionRecord> = env


### PR DESCRIPTION
## Summary

Fixes all four issues assigned to @dzekojohn4.

---

### #186 — Authentication Checks Removed in Admin Functions

**Files:** `swaptrade-contracts/counter/src/lib.rs`

- Added `caller: Address` parameter to `pause_trading`, `resume_trading`, and `set_admin`.
- Each function now calls `caller.require_auth()` and `require_admin(&env, &caller)` before mutating state.
- Unauthorized callers receive `SwapTradeError::NotAdmin`.

---

### #187 — Staking Distribution Does Not Distribute Rewards

**Files:** `swaptrade-contracts/counter/src/staking_bonus.rs`

- Added `StakingBonusKey::StakerRegistry` to track all staker addresses (Soroban storage does not support key enumeration).
- `stake()` registers the user in the registry on their first stake.
- `execute_distribution()` now iterates every registered staker, sums `bonus_amount` for all active unclaimed stakes, updates `UserEarnedBonuses`, and correctly populates `total_distributed` and `recipient_count`.

---

### #188 — LP Token Rounding Errors Enable Exploitation

**Files:** `swaptrade-contracts/counter/src/liquidity_pool.rs`

- Introduced `MIN_LP_TOKENS = 1000` constant.
- `add_liquidity` rejects any deposit that would mint fewer than 1000 LP tokens with `ContractError::InvalidAmount`, preventing dust/rounding drain attacks.

---

### #189 — Rate Limiter State Not Properly Cleaned

**Files:** `swaptrade-contracts/counter/src/rate_limit.rs`, `lib.rs`

- Added `RateLimiter::cleanup_rate_limits(env, user)` which removes the previous hourly swap window and previous daily LP window for a given user.
- Active (current) windows are never touched.
- Exposed as `CounterContract::cleanup_rate_limits(env, user) -> u32` in the contract interface.

---

Closes #186
Closes #187
Closes #188
Closes #189