### PR TITLE
Implemented NFT Fractionalization & Lending Protocol for Real-World Asset Simulation

### DIFF
--- a/swaptrade-contracts/counter/src/nft_fractional.rs
+++ b/swaptrade-contracts/counter/src/nft_fractional.rs
@@ -699,6 +699,506 @@ pub fn get_ownership_percentage(
         fractional_registry.get_shares(collection_id, token_id, shareholder),
         nft_registry.get_nft(collection_id, token_id),
     ) {
+        if nft.total_supply == 0 {
+            return 0;
+        }
+        // Calculate ownership percentage in basis points
+        (share.shares as u128 * 10000 / nft.total_supply as u128) as u32
+    } else {
+        0
+    }
+}
+
+// =============================================================================
+// ERC4626 FRACTIONAL VAULT IMPLEMENTATION
+// =============================================================================
+
+/// Create an ERC4626-compliant fractional vault for an NFT
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `owner` - NFT owner
+/// * `collection_id` - NFT collection ID
+/// * `token_id` - NFT token ID
+/// * `total_shares` - Total shares to mint
+/// * `share_symbol` - Symbol for vault shares
+///
+/// # Returns
+/// * `Result<u64, NFTError>` - Vault ID on success
+pub fn create_fractional_vault(
+    env: &Env,
+    owner: Address,
+    collection_id: u64,
+    token_id: u64,
+    total_shares: u64,
+    share_symbol: Symbol,
+) -> Result<u64, NFTError> {
+    owner.require_auth();
+
+    if is_marketplace_paused(env) {
+        return Err(NFTError::MarketplacePaused);
+    }
+
+    if emergency::is_frozen(env, owner.clone()) {
+        return Err(NFTError::UserFrozen);
+    }
+
+    // Validate share count
+    if total_shares < MIN_SHARES || total_shares > MAX_SHARES {
+        return Err(NFTError::FractionalizationLimit);
+    }
+
+    // Get NFT and verify ownership
+    let mut nft_registry: NFTRegistry = env
+        .storage()
+        .instance()
+        .get(&NFT_REGISTRY_KEY)
+        .ok_or(NFTError::NFTNotFound)?;
+    
+    let mut nft = nft_registry
+        .get_nft(collection_id, token_id)
+        .ok_or(NFTError::NFTNotFound)?;
+
+    if nft.owner != owner {
+        return Err(NFTError::NotOwner);
+    }
+
+    if nft.is_fractionalized {
+        return Err(NFTError::AlreadyFractionalized);
+    }
+
+    // Check if NFT is already in a vault
+    let vault_registry_check: FractionalVaultRegistry = env
+        .storage()
+        .instance()
+        .get(&FRACTIONAL_VAULT_REGISTRY_KEY)
+        .unwrap_or_else(|| FractionalVaultRegistry::new(env));
+    
+    // Verify NFT isn't already collateralized
+    let loan_registry_check: LoanRegistry = env
+        .storage()
+        .instance()
+        .get(&LOAN_REGISTRY_KEY)
+        .unwrap_or_else(|| LoanRegistry::new(env));
+    if loan_registry_check.get_loan_by_collateral(collection_id, token_id).is_some() {
+        return Err(NFTError::AlreadyCollateralized);
+    }
+
+    // Create vault
+    let vault_id = get_next_vault_id(env);
+    let current_time = env.ledger().timestamp();
+
+    // Get NFT price from oracle to set total_assets
+    let nft_price = crate::nft_lending::get_nft_price_from_oracle(env, collection_id, token_id)?;
+
+    let vault = FractionalVault {
+        vault_id,
+        collection_id,
+        token_id,
+        asset: Symbol::new(env, &format!("NFT{}{}", collection_id, token_id)),
+        share_symbol,
+        total_shares,
+        total_assets: nft_price,
+        share_supply: 0,
+        created_at: current_time,
+        owner: owner.clone(),
+        is_active: true,
+    };
+
+    // Store vault
+    let mut vault_registry: FractionalVaultRegistry = env
+        .storage()
+        .instance()
+        .get(&FRACTIONAL_VAULT_REGISTRY_KEY)
+        .unwrap_or_else(|| FractionalVaultRegistry::new(env));
+    
+    vault_registry.create_vault(env, vault);
+    env.storage()
+        .instance()
+        .set(&FRACTIONAL_VAULT_REGISTRY_KEY, &vault_registry);
+
+    // Mark NFT as fractionalized and lock it in the vault
+    nft.is_fractionalized = true;
+    nft.total_supply = total_shares;
+    nft.circulating_supply = 0;
+    nft_registry.update_nft(nft);
+    env.storage()
+        .instance()
+        .set(&NFT_REGISTRY_KEY, &nft_registry);
+
+    // Mint initial shares to the vault owner
+    mint_vault_shares(env, owner.clone(), vault_id, total_shares)?;
+
+    // Emit events
+    crate::nft_events::emit_fractional_vault_created(env, vault_id, collection_id, token_id, share_symbol);
+
+    Ok(vault_id)
+}
+
+/// ERC4626: Mint vault shares by depositing assets (or in this case, buying fractional shares)
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `recipient` - Address to mint shares to
+/// * `vault_id` - Vault ID
+/// * `shares` - Number of shares to mint
+///
+/// # Returns
+/// * `Result<(), NFTError>` - Success or error
+pub fn mint_vault_shares(
+    env: &Env,
+    recipient: Address,
+    vault_id: u64,
+    shares: u64,
+) -> Result<(), NFTError> {
+    if shares < MIN_VAULT_MINT_AMOUNT {
+        return Err(NFTError::InvalidAmount);
+    }
+
+    // Get vault
+    let mut vault_registry: FractionalVaultRegistry = env
+        .storage()
+        .instance()
+        .get(&FRACTIONAL_VAULT_REGISTRY_KEY)
+        .ok_or(NFTError::VaultNotFound)?;
+    
+    let mut vault = vault_registry
+        .get_vault(vault_id)
+        .ok_or(NFTError::VaultNotFound)?;
+
+    if !vault.is_active {
+        return Err(NFTError::MarketplacePaused);
+    }
+
+    // Check we don't mint more than total shares
+    if vault.share_supply + shares > vault.total_shares {
+        return Err(NFTError::InsufficientShares);
+    }
+
+    // Update vault share supply
+    vault.share_supply += shares;
+    vault_registry.update_vault(vault);
+    env.storage()
+        .instance()
+        .set(&FRACTIONAL_VAULT_REGISTRY_KEY, &vault_registry);
+
+    // Record shares for the recipient
+    let mut vault_shares: Map<(u64, Address), VaultShare> = env
+        .storage()
+        .instance()
+        .get(&VAULT_SHARES_KEY)
+        .unwrap_or_else(|| Map::new(env));
+    
+    let share_key = (vault_id, recipient.clone());
+    let mut share = vault_shares
+        .get(share_key.clone())
+        .unwrap_or_else(|| VaultShare {
+            vault_id,
+            owner: recipient.clone(),
+            shares: 0,
+            last_deposit: env.ledger().timestamp(),
+        });
+    
+    share.shares += shares;
+    share.last_deposit = env.ledger().timestamp();
+    
+    vault_shares.set(share_key, share);
+    env.storage()
+        .instance()
+        .set(&VAULT_SHARES_KEY, &vault_shares);
+
+    // Update NFT circulating supply
+    let mut nft_registry: NFTRegistry = env
+        .storage()
+        .instance()
+        .get(&NFT_REGISTRY_KEY)
+        .unwrap_or_else(|| NFTRegistry::new(env));
+    
+    let mut nft = nft_registry
+        .get_nft(vault.collection_id, vault.token_id)
+        .ok_or(NFTError::NFTNotFound)?;
+    nft.circulating_supply += shares;
+    nft_registry.update_nft(nft);
+    env.storage()
+        .instance()
+        .set(&NFT_REGISTRY_KEY, &nft_registry);
+
+    // Update recipient's portfolio
+    let mut portfolio_registry: Map<Address, NFTPortfolio> = env
+        .storage()
+        .instance()
+        .get(&PORTFOLIO_REGISTRY_KEY)
+        .unwrap_or_else(|| Map::new(env));
+    
+    let mut portfolio = portfolio_registry
+        .get(recipient.clone())
+        .unwrap_or_else(|| NFTPortfolio::new(env, recipient.clone()));
+    portfolio.total_fractional_shares += shares;
+    portfolio_registry.set(recipient.clone(), portfolio);
+    env.storage()
+        .instance()
+        .set(&PORTFOLIO_REGISTRY_KEY, &portfolio_registry);
+
+    // Emit mint event
+    crate::nft_events::emit_vault_shares_minted(env, vault_id, recipient, shares);
+
+    Ok(())
+}
+
+/// ERC4626: Withdraw assets from the vault by burning shares
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `owner` - Share owner withdrawing
+/// * `vault_id` - Vault ID
+/// * `shares` - Number of shares to burn/withdraw
+///
+/// # Returns
+/// * `Result<(), NFTError>` - Success or error
+pub fn withdraw_vault_shares(
+    env: &Env,
+    owner: Address,
+    vault_id: u64,
+    shares: u64,
+) -> Result<(), NFTError> {
+    owner.require_auth();
+
+    if shares == 0 {
+        return Err(NFTError::InvalidAmount);
+    }
+
+    // Check withdrawal delay
+    let mut vault_shares_map: Map<(u64, Address), VaultShare> = env
+        .storage()
+        .instance()
+        .get(&VAULT_SHARES_KEY)
+        .ok_or(NFTError::InsufficientBalance)?;
+    
+    let share_key = (vault_id, owner.clone());
+    let mut vault_share = vault_shares_map
+        .get(share_key.clone())
+        .ok_or(NFTError::InsufficientBalance)?;
+
+    if vault_share.shares < shares {
+        return Err(NFTError::InsufficientBalance);
+    }
+
+    if WITHDRAWAL_DELAY > 0 && env.ledger().timestamp() < vault_share.last_deposit + WITHDRAWAL_DELAY {
+        return Err(NFTError::WithdrawalTooEarly);
+    }
+
+    // Get vault
+    let mut vault_registry: FractionalVaultRegistry = env
+        .storage()
+        .instance()
+        .get(&FRACTIONAL_VAULT_REGISTRY_KEY)
+        .ok_or(NFTError::VaultNotFound)?;
+    
+    let mut vault = vault_registry
+        .get_vault(vault_id)
+        .ok_or(NFTError::VaultNotFound)?;
+
+    // Calculate withdrawal fee (max 0.5%)
+    let fee_amount = (shares as u128 * MAX_WITHDRAWAL_FEE_BPS as u128 / 10000) as u64;
+    let actual_withdrawal = shares - fee_amount;
+
+    // Burn shares
+    vault.share_supply -= shares;
+    vault_registry.update_vault(vault);
+    env.storage()
+        .instance()
+        .set(&FRACTIONAL_VAULT_REGISTRY_KEY, &vault_registry);
+
+    // Update user's shares
+    vault_share.shares -= shares;
+    if vault_share.shares == 0 {
+        vault_shares_map.remove(share_key);
+    } else {
+        vault_shares_map.set(share_key, vault_share);
+    }
+    env.storage()
+        .instance()
+        .set(&VAULT_SHARES_KEY, &vault_shares_map);
+
+    // If user owns all remaining shares, they can defractionalize
+    if vault.share_supply == 0 && vault.owner == owner {
+        // Defractionalize the NFT
+        let mut nft_registry: NFTRegistry = env
+            .storage()
+            .instance()
+            .get(&NFT_REGISTRY_KEY)
+            .unwrap();
+        let mut nft = nft_registry.get_nft(vault.collection_id, vault.token_id).unwrap();
+        nft.is_fractionalized = false;
+        nft.total_supply = 1;
+        nft.circulating_supply = 1;
+        nft.owner = owner.clone();
+        nft_registry.update_nft(nft);
+        env.storage()
+            .instance()
+            .set(&NFT_REGISTRY_KEY, &nft_registry);
+        
+        // Deactivate the vault
+        let mut updated_vault = vault;
+        updated_vault.is_active = false;
+        vault_registry.update_vault(updated_vault);
+        env.storage()
+            .instance()
+            .set(&FRACTIONAL_VAULT_REGISTRY_KEY, &vault_registry);
+    }
+
+    // Update NFT circulating supply
+    let mut nft_registry: NFTRegistry = env
+        .storage()
+        .instance()
+        .get(&NFT_REGISTRY_KEY)
+        .unwrap();
+    let mut nft = nft_registry.get_nft(vault.collection_id, vault.token_id).unwrap();
+    nft.circulating_supply -= actual_withdrawal;
+    nft_registry.update_nft(nft);
+    env.storage()
+        .instance()
+        .set(&NFT_REGISTRY_KEY, &nft_registry);
+
+    // Update portfolio
+    let mut portfolio_registry: Map<Address, NFTPortfolio> = env
+        .storage()
+        .instance()
+        .get(&PORTFOLIO_REGISTRY_KEY)
+        .unwrap();
+    let mut portfolio = portfolio_registry.get(owner.clone()).unwrap();
+    portfolio.total_fractional_shares -= shares;
+    portfolio_registry.set(owner.clone(), portfolio);
+    env.storage()
+        .instance()
+        .set(&PORTFOLIO_REGISTRY_KEY, &portfolio_registry);
+
+    // Emit withdrawal event
+    crate::nft_events::emit_vault_shares_withdrawn(env, vault_id, owner, actual_withdrawal, fee_amount);
+
+    Ok(())
+}
+
+/// ERC4626: Convert shares to assets (get the underlying value of shares)
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `vault_id` - Vault ID
+/// * `shares` - Number of shares
+///
+/// # Returns
+/// * `Result<i128, NFTError>` - Asset value in the vault's denomination
+pub fn convert_to_assets(env: &Env, vault_id: u64, shares: u64) -> Result<i128, NFTError> {
+    let vault_registry: FractionalVaultRegistry = env
+        .storage()
+        .instance()
+        .get(&FRACTIONAL_VAULT_REGISTRY_KEY)
+        .ok_or(NFTError::VaultNotFound)?;
+    
+    let vault = vault_registry
+        .get_vault(vault_id)
+        .ok_or(NFTError::VaultNotFound)?;
+
+    if vault.total_shares == 0 {
+        return Ok(0);
+    }
+
+    // Calculate proportional asset value
+    Ok((vault.total_assets as u128 * shares as u128 / vault.total_shares as u128) as i128)
+}
+
+/// ERC4626: Convert assets to shares
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `vault_id` - Vault ID
+/// * `assets` - Amount of assets
+///
+/// # Returns
+/// * `Result<u64, NFTError>` - Number of shares the assets represent
+pub fn convert_to_shares(env: &Env, vault_id: u64, assets: i128) -> Result<u64, NFTError> {
+    let vault_registry: FractionalVaultRegistry = env
+        .storage()
+        .instance()
+        .get(&FRACTIONAL_VAULT_REGISTRY_KEY)
+        .ok_or(NFTError::VaultNotFound)?;
+    
+    let vault = vault_registry
+        .get_vault(vault_id)
+        .ok_or(NFTError::VaultNotFound)?;
+
+    if vault.total_assets == 0 {
+        return Ok(0);
+    }
+
+    // Calculate proportional share amount
+    Ok((vault.total_shares as u128 * assets as u128 / vault.total_assets as u128) as u64)
+}
+
+/// Get vault share balance for an owner
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `vault_id` - Vault ID
+/// * `owner` - Share owner address
+///
+/// # Returns
+/// * `u64` - Number of shares owned
+pub fn balance_of(env: &Env, vault_id: u64, owner: Address) -> u64 {
+    let vault_shares: Map<(u64, Address), VaultShare> = env
+        .storage()
+        .instance()
+        .get(&VAULT_SHARES_KEY)
+        .unwrap_or_else(|| Map::new(env));
+    
+    if let Some(share) = vault_shares.get((vault_id, owner)) {
+        share.shares
+    } else {
+        0
+    }
+}
+
+/// Get total vault share supply
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `vault_id` - Vault ID
+///
+/// * `Result<u64, NFTError>` - Total shares in circulation
+pub fn total_supply(env: &Env, vault_id: u64) -> Result<u64, NFTError> {
+    let vault_registry: FractionalVaultRegistry = env
+        .storage()
+        .instance()
+        .get(&FRACTIONAL_VAULT_REGISTRY_KEY)
+        .ok_or(NFTError::VaultNotFound)?;
+    
+    let vault = vault_registry
+        .get_vault(vault_id)
+        .ok_or(NFTError::VaultNotFound)?;
+    
+    Ok(vault.share_supply)
+}
+
+/// Get vault by NFT collection and token ID
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `collection_id` - NFT collection ID
+/// * `token_id` - NFT token ID
+///
+/// * `Option<FractionalVault>` - The vault if it exists
+pub fn get_vault_by_nft(env: &Env, collection_id: u64, token_id: u64) -> Option<FractionalVault> {
+    let vault_registry: FractionalVaultRegistry = env
+        .storage()
+        .instance()
+        .get(&FRACTIONAL_VAULT_REGISTRY_KEY)
+        .unwrap_or_else(|| FractionalVaultRegistry::new(env));
+    
+    // Use O(1) reverse mapping lookup from registry
+    vault_registry.get_vault_by_nft(collection_id, token_id)
+}
+        nft_registry.get_nft(collection_id, token_id),
+    ) {
         if nft.total_supply > 0 {
             ((share.shares as u128 * 10000) / nft.total_supply as u128) as u32
         } else {

--- a/swaptrade-contracts/counter/src/nft_lending.rs
+++ b/swaptrade-contracts/counter/src/nft_lending.rs
@@ -4,7 +4,8 @@ use crate::nft_errors::NFTError;
 use crate::nft_minting::{get_nft, is_owner};
 use crate::nft_storage::*;
 use crate::nft_types::*;
-use soroban_sdk::{symbol_short, Address, Env, Map, String, Symbol, Vec};
+use crate::oracle;
+use soroban_sdk::{symbol_short, Address, Env, Map, Symbol, Vec};
 
 /// Minimum loan duration (1 day)
 const MIN_LOAN_DURATION: u64 = 86400;
@@ -17,14 +18,18 @@ const LIQUIDATION_GRACE_PERIOD: u64 = 86400; // 1 day
 /// Precision for interest calculations (10^18)
 const INTEREST_PRECISION: u128 = 1_000_000_000_000_000_000u128;
 
-/// Loan-to-value ratio in basis points that triggers liquidation (70%)
-const LIQUIDATION_TRIGGER_LTV_BPS: u32 = 7000;
-/// Partial liquidation threshold LTV (100%)
-const PARTIAL_LIQUIDATION_LTV_BPS: u32 = 10000;
-/// Liquidation penalty charged to borrower in basis points (5%)
-const LIQUIDATION_PENALTY_BPS: u32 = 500;
-/// Protocol fee collected from liquidation in basis points (1%)
-const LIQUIDATION_PROTOCOL_FEE_BPS: u32 = 100;
+/// Protocol requirements from acceptance criteria
+/// Maximum Loan-to-Value ratio (60% = 6000 bps)
+const MAX_LTV_BPS: u32 = 6000;
+/// Liquidation collateralization ratio (150% = 1.5x, so LTV must stay below 66.67%)
+/// If collateralization ratio < 150%, loan can be liquidated
+const LIQUIDATION_COLLATERALIZATION_RATIO_MIN: u128 = 150; // 150%
+/// Liquidation bonus for liquidators (5%)
+const LIQUIDATION_BONUS_BPS: u32 = 500;
+/// Base utilization rate parameters for dynamic interest rates
+const OPTIMAL_UTILIZATION_RATE_BPS: u32 = 8000; // 80%
+const RATE_SLOPE_1_BPS: u32 = 100; // 1% additional rate when below optimal
+const RATE_SLOPE_2_BPS: u32 = 500; // 5% additional rate when above optimal
 /// Maximum queued loans
 const MAX_LIQUIDATION_QUEUE_SIZE: usize = 128;
 
@@ -493,6 +498,721 @@ fn update_portfolio_on_loan_given(env: &Env, lender: Address) -> Result<(), NFTE
     env.storage()
         .instance()
         .set(&PORTFOLIO_REGISTRY_KEY, &portfolio_registry);
+
+    Ok(())
+}
+
+// =============================================================================
+// LENDING POOL IMPLEMENTATION (PEER-TO-POOL LENDING)
+// =============================================================================
+
+/// Create a new lending pool
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `creator` - Pool creator address
+/// * `asset` - The asset (e.g., USDC) that the pool accepts
+/// * `reserve_factor_bps` - Protocol reserve fee in basis points
+/// * `base_rate_bps` - Base interest rate in basis points
+///
+/// # Returns
+/// * `Result<u64, NFTError>` - Pool ID on success
+pub fn create_lending_pool(
+    env: &Env,
+    creator: Address,
+    asset: Symbol,
+    reserve_factor_bps: u32,
+    base_rate_bps: u32,
+) -> Result<u64, NFTError> {
+    // Only admin can create pools (simplified - in production would have proper access control)
+    creator.require_auth();
+
+    let pool_id = get_next_pool_id(env);
+    let current_time = env.ledger().timestamp();
+
+    let pool = LendingPool {
+        pool_id,
+        asset,
+        total_deposited: 0,
+        total_borrowed: 0,
+        reserve_factor_bps,
+        base_rate_bps,
+        is_active: true,
+        created_at: current_time,
+    };
+
+    let mut pool_registry: LendingPoolRegistry = env
+        .storage()
+        .instance()
+        .get(&LENDING_POOL_REGISTRY_KEY)
+        .unwrap_or_else(|| LendingPoolRegistry::new(env));
+    
+    pool_registry.create_pool(env, pool);
+    env.storage()
+        .instance()
+        .set(&LENDING_POOL_REGISTRY_KEY, &pool_registry);
+
+    // Emit event
+    crate::nft_events::emit_lending_pool_created(env, pool_id, asset);
+
+    Ok(pool_id)
+}
+
+/// Deposit assets into a lending pool to earn interest
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `lender` - Lender address depositing funds
+/// * `pool_id` - ID of the lending pool
+/// * `amount` - Amount to deposit
+///
+/// # Returns
+/// * `Result<(), NFTError>` - Success or error
+pub fn deposit_to_lending_pool(
+    env: &Env,
+    lender: Address,
+    pool_id: u64,
+    amount: i128,
+) -> Result<(), NFTError> {
+    lender.require_auth();
+
+    if emergency::is_frozen(env, lender.clone()) {
+        return Err(NFTError::UserFrozen);
+    }
+
+    if amount <= 0 {
+        return Err(NFTError::InvalidAmount);
+    }
+
+    // Get pool
+    let mut pool_registry: LendingPoolRegistry = env
+        .storage()
+        .instance()
+        .get(&LENDING_POOL_REGISTRY_KEY)
+        .ok_or(NFTError::LoanNotFound)?;
+    
+    let mut pool = pool_registry
+        .get_pool(pool_id)
+        .ok_or(NFTError::LoanNotFound)?;
+
+    if !pool.is_active {
+        return Err(NFTError::MarketplacePaused);
+    }
+
+    // Update pool totals
+    pool.total_deposited = pool.total_deposited.checked_add(amount).ok_or(NFTError::AmountOverflow)?;
+    pool_registry.update_pool(pool);
+    env.storage()
+        .instance()
+        .set(&LENDING_POOL_REGISTRY_KEY, &pool_registry);
+
+    // Record lender deposit
+    let mut lender_deposits: Map<(u64, Address), LenderDeposit> = env
+        .storage()
+        .instance()
+        .get(&LENDER_DEPOSITS_KEY)
+        .unwrap_or_else(|| Map::new(env));
+    
+    let deposit_key = (pool_id, lender.clone());
+    let mut deposit = lender_deposits
+        .get(deposit_key.clone())
+        .unwrap_or_else(|| LenderDeposit {
+            pool_id,
+            lender: lender.clone(),
+            amount: 0,
+            shares: 0,
+            deposited_at: env.ledger().timestamp(),
+        });
+    
+    // Calculate shares (simplified - in production would use proper share price calculations)
+    let new_shares = amount; // 1:1 initially, accumulates interest over time
+    deposit.amount = deposit.amount.checked_add(amount).ok_or(NFTError::AmountOverflow)?;
+    deposit.shares = deposit.shares.checked_add(new_shares).ok_or(NFTError::AmountOverflow)?;
+    
+    lender_deposits.set(deposit_key, deposit);
+    env.storage()
+        .instance()
+        .set(&LENDER_DEPOSITS_KEY, &lender_deposits);
+
+    // Update portfolio
+    let mut portfolio_registry: Map<Address, NFTPortfolio> = env
+        .storage()
+        .instance()
+        .get(&PORTFOLIO_REGISTRY_KEY)
+        .unwrap_or_else(|| Map::new(env));
+    
+    let mut portfolio = portfolio_registry
+        .get(lender.clone())
+        .unwrap_or_else(|| NFTPortfolio::new(env, lender.clone()));
+    portfolio.total_fractional_shares = portfolio.total_fractional_shares.saturating_add(amount as u64);
+    portfolio_registry.set(lender.clone(), portfolio);
+    env.storage()
+        .instance()
+        .set(&PORTFOLIO_REGISTRY_KEY, &portfolio_registry);
+
+    // Emit event
+    crate::nft_events::emit_lending_pool_deposit(env, pool_id, lender, amount);
+
+    Ok(())
+}
+
+/// Withdraw assets from a lending pool
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `lender` - Lender address withdrawing funds
+/// * `pool_id` - ID of the lending pool
+/// * `amount` - Amount to withdraw
+///
+/// # Returns
+/// * `Result<(), NFTError>` - Success or error
+pub fn withdraw_from_lending_pool(
+    env: &Env,
+    lender: Address,
+    pool_id: u64,
+    amount: i128,
+) -> Result<(), NFTError> {
+    lender.require_auth();
+
+    if emergency::is_frozen(env, lender.clone()) {
+        return Err(NFTError::UserFrozen);
+    }
+
+    if amount <= 0 {
+        return Err(NFTError::InvalidAmount);
+    }
+
+    // Get pool
+    let mut pool_registry: LendingPoolRegistry = env
+        .storage()
+        .instance()
+        .get(&LENDING_POOL_REGISTRY_KEY)
+        .ok_or(NFTError::LoanNotFound)?;
+    
+    let mut pool = pool_registry
+        .get_pool(pool_id)
+        .ok_or(NFTError::LoanNotFound)?;
+
+    if !pool.is_active {
+        return Err(NFTError::MarketplacePaused);
+    }
+
+    // Check available liquidity
+    let available_liquidity = pool.total_deposited - pool.total_borrowed;
+    if amount > available_liquidity {
+        return Err(NFTError::InsufficientBalance);
+    }
+
+    // Check lender's deposit
+    let mut lender_deposits: Map<(u64, Address), LenderDeposit> = env
+        .storage()
+        .instance()
+        .get(&LENDER_DEPOSITS_KEY)
+        .ok_or(NFTError::InsufficientBalance)?;
+    
+    let deposit_key = (pool_id, lender.clone());
+    let mut deposit = lender_deposits
+        .get(deposit_key.clone())
+        .ok_or(NFTError::InsufficientBalance)?;
+
+    if deposit.amount < amount {
+        return Err(NFTError::InsufficientBalance);
+    }
+
+    // Update pool and deposit
+    pool.total_deposited = pool.total_deposited.checked_sub(amount).ok_or(NFTError::AmountOverflow)?;
+    pool_registry.update_pool(pool);
+    env.storage()
+        .instance()
+        .set(&LENDING_POOL_REGISTRY_KEY, &pool_registry);
+
+    deposit.amount = deposit.amount.checked_sub(amount).ok_or(NFTError::AmountOverflow)?;
+    deposit.shares = deposit.shares.checked_sub(amount).ok_or(NFTError::AmountOverflow)?;
+    
+    if deposit.amount == 0 {
+        lender_deposits.remove(deposit_key);
+    } else {
+        lender_deposits.set(deposit_key, deposit);
+    }
+    env.storage()
+        .instance()
+        .set(&LENDER_DEPOSITS_KEY, &lender_deposits);
+
+    // Emit event
+    crate::nft_events::emit_lending_pool_withdrawal(env, pool_id, lender, amount);
+
+    Ok(())
+}
+
+/// Calculate dynamic interest rate based on pool utilization
+///
+/// # Arguments
+/// * `pool` - The lending pool
+///
+/// # Returns
+/// * `u32` - Current interest rate in basis points
+pub fn calculate_dynamic_interest_rate(pool: &LendingPool) -> u32 {
+    if pool.total_deposited == 0 {
+        return pool.base_rate_bps;
+    }
+
+    let utilization_bps = ((pool.total_borrowed as u128) * 10000 / pool.total_deposited as u128) as u32;
+    
+    if utilization_bps <= OPTIMAL_UTILIZATION_RATE_BPS {
+        // Below optimal utilization: base_rate + slope_1 * (utilization / optimal)
+        pool.base_rate_bps + RATE_SLOPE_1_BPS * utilization_bps / OPTIMAL_UTILIZATION_RATE_BPS
+    } else {
+        // Above optimal utilization: base_rate + slope_1 + slope_2 * (utilization - optimal) / (100% - optimal)
+        let excess_utilization = utilization_bps - OPTIMAL_UTILIZATION_RATE_BPS;
+        let max_excess = 10000 - OPTIMAL_UTILIZATION_RATE_BPS;
+        pool.base_rate_bps + RATE_SLOPE_1_BPS + RATE_SLOPE_2_BPS * excess_utilization / max_excess
+    }
+}
+
+/// Borrow from a lending pool using NFT as collateral
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `borrower` - Borrower address
+/// * `pool_id` - Lending pool ID
+/// * `collection_id` - NFT collection ID
+/// * `token_id` - NFT token ID
+/// * `loan_amount` - Amount to borrow
+/// * `duration` - Loan duration in seconds
+///
+/// # Returns
+/// * `Result<u64, NFTError>` - Loan ID on success
+pub fn borrow_from_lending_pool(
+    env: &Env,
+    borrower: Address,
+    pool_id: u64,
+    collection_id: u64,
+    token_id: u64,
+    loan_amount: i128,
+    duration: u64,
+) -> Result<u64, NFTError> {
+    borrower.require_auth();
+
+    if is_marketplace_paused(env) {
+        return Err(NFTError::MarketplacePaused);
+    }
+
+    if emergency::is_frozen(env, borrower.clone()) {
+        return Err(NFTError::UserFrozen);
+    }
+
+    // Validate loan amount and duration
+    if loan_amount <= 0 {
+        return Err(NFTError::InvalidAmount);
+    }
+
+    if duration < MIN_LOAN_DURATION || duration > MAX_LOAN_DURATION {
+        return Err(NFTError::InvalidDuration);
+    }
+
+    // Get pool and check available liquidity
+    let mut pool_registry: LendingPoolRegistry = env
+        .storage()
+        .instance()
+        .get(&LENDING_POOL_REGISTRY_KEY)
+        .ok_or(NFTError::LoanNotFound)?;
+    
+    let mut pool = pool_registry
+        .get_pool(pool_id)
+        .ok_or(NFTError::LoanNotFound)?;
+
+    if !pool.is_active {
+        return Err(NFTError::MarketplacePaused);
+    }
+
+    let available_liquidity = pool.total_deposited - pool.total_borrowed;
+    if loan_amount > available_liquidity {
+        return Err(NFTError::InsufficientBalance);
+    }
+
+    // Get NFT and verify ownership
+    let mut nft_registry: NFTRegistry = env
+        .storage()
+        .instance()
+        .get(&NFT_REGISTRY_KEY)
+        .ok_or(NFTError::NFTNotFound)?;
+    
+    let mut nft = nft_registry
+        .get_nft(collection_id, token_id)
+        .ok_or(NFTError::NFTNotFound)?;
+
+    if nft.owner != borrower {
+        return Err(NFTError::NotOwner);
+    }
+
+    // Check if already collateralized or fractionalized
+    let loan_registry_check: LoanRegistry = env
+        .storage()
+        .instance()
+        .get(&LOAN_REGISTRY_KEY)
+        .unwrap_or_else(|| LoanRegistry::new(env));
+    if loan_registry_check
+        .get_loan_by_collateral(collection_id, token_id)
+        .is_some() {
+        return Err(NFTError::AlreadyCollateralized);
+    }
+
+    if nft.is_fractionalized {
+        return Err(NFTError::UnsupportedOperation);
+    }
+
+    // Get NFT price from oracle to calculate LTV
+    let nft_price = get_nft_price_from_oracle(env, collection_id, token_id)?;
+    
+    // Calculate maximum allowed loan amount (60% LTV)
+    let max_loan_amount = (nft_price as u128 * MAX_LTV_BPS as u128 / 10000) as i128;
+    if loan_amount > max_loan_amount {
+        return Err(NFTError::InvalidAmount);
+    }
+
+    // Calculate interest with dynamic rate
+    let current_rate = calculate_dynamic_interest_rate(&pool);
+    let days = (duration / 86400) as u128;
+    let daily_interest = (loan_amount as u128 * current_rate as u128 / 10000) as i128;
+    let total_interest = daily_interest * days as i128;
+    let repayment_amount = loan_amount.checked_add(total_interest).ok_or(NFTError::AmountOverflow)?;
+
+    // Create loan
+    let loan_id = get_next_loan_id(env);
+    let current_time = env.ledger().timestamp();
+
+    let loan = NFTLoan {
+        loan_id,
+        token_id,
+        collection_id,
+        borrower: borrower.clone(),
+        lender: Address::from_string(env, &pool_id.to_string()), // Pool is the lender
+        loan_amount,
+        interest_rate_bps: current_rate,
+        repayment_amount,
+        start_time: current_time,
+        duration,
+        due_date: current_time + duration,
+        is_active: true,
+        is_repaid: false,
+        is_liquidated: false,
+    };
+
+    // Update pool
+    pool.total_borrowed = pool.total_borrowed.checked_add(loan_amount).ok_or(NFTError::AmountOverflow)?;
+    pool_registry.update_pool(pool);
+    env.storage()
+        .instance()
+        .set(&LENDING_POOL_REGISTRY_KEY, &pool_registry);
+
+    // Store loan
+    let mut loan_registry: LoanRegistry = env
+        .storage()
+        .instance()
+        .get(&LOAN_REGISTRY_KEY)
+        .unwrap_or_else(|| LoanRegistry::new(env));
+    loan_registry.create_loan(env, loan);
+    env.storage()
+        .instance()
+        .set(&LOAN_REGISTRY_KEY, &loan_registry);
+
+    // Update portfolios
+    update_portfolio_on_loan_taken(env, borrower.clone())?;
+
+    // Emit events
+    crate::nft_events::emit_loan_requested(
+        env,
+        loan_id,
+        collection_id,
+        token_id,
+        borrower,
+        loan_amount,
+    );
+    crate::nft_events::emit_loan_funded(env, loan_id, Address::from_string(env, &pool_id.to_string()), loan_amount);
+
+    Ok(loan_id)
+}
+
+/// Helper to get NFT price from oracle
+fn get_nft_price_from_oracle(env: &Env, collection_id: u64, token_id: u64) -> Result<i128, NFTError> {
+    // Get valuation from registry first
+    let valuation_registry: ValuationRegistry = env
+        .storage()
+        .instance()
+        .get(&VALUATION_REGISTRY_KEY)
+        .unwrap_or_else(|| ValuationRegistry::new(env));
+    
+    if let Some(valuation) = valuation_registry.get_valuation(collection_id, token_id) {
+        if valuation.oracle_verified {
+            return Ok(valuation.floor_price);
+        }
+    }
+
+    // Fallback to oracle price feed
+    let usdc = symbol_short!("USDC");
+    let nft_token = Symbol::new(env, &format!("NFT{}{}", collection_id, token_id));
+    match oracle::get_price_safe(env, (nft_token, usdc)) {
+        Ok(price) => Ok(price as i128),
+        Err(_) => Err(NFTError::PriceNotFound),
+    }
+}
+
+/// Check if a loan can be liquidated (collateralization ratio < 150%)
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `loan_id` - Loan ID to check
+///
+/// # Returns
+/// * `Result<bool, NFTError>` - Whether loan can be liquidated
+pub fn can_liquidate_loan(env: &Env, loan_id: u64) -> Result<bool, NFTError> {
+    let loan_registry: LoanRegistry = env
+        .storage()
+        .instance()
+        .get(&LOAN_REGISTRY_KEY)
+        .ok_or(NFTError::LoanNotFound)?;
+    
+    let loan = loan_registry
+        .get_loan(loan_id)
+        .ok_or(NFTError::LoanNotFound)?;
+
+    if !loan.is_active || loan.is_repaid || loan.is_liquidated {
+        return Ok(false);
+    }
+
+    // Get current NFT price from oracle
+    let nft_price = get_nft_price_from_oracle(env, loan.collection_id, loan.token_id)?;
+    
+    // Calculate current collateralization ratio: (collateral value / loan amount) * 100
+    let collateralization_ratio = (nft_price as u128 * 100) / loan.loan_amount as u128;
+
+    // Also check if loan is overdue
+    let current_time = env.ledger().timestamp();
+    let is_overdue = current_time > loan.due_date + LIQUIDATION_GRACE_PERIOD;
+
+    // Can liquidate if either collateralization < 150% OR loan is overdue
+    Ok(collateralization_ratio < LIQUIDATION_COLLATERALIZATION_RATIO_MIN || is_overdue)
+}
+
+/// Liquidate an undercollateralized loan
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `liquidator` - Address executing liquidation
+/// * `loan_id` - Loan ID to liquidate
+///
+/// # Returns
+/// * `Result<(), NFTError>` - Success or error
+pub fn liquidate_undercollateralized_loan(
+    env: &Env,
+    liquidator: Address,
+    loan_id: u64,
+) -> Result<(), NFTError> {
+    liquidator.require_auth();
+
+    if emergency::is_frozen(env, liquidator.clone()) {
+        return Err(NFTError::UserFrozen);
+    }
+
+    // Check if loan can be liquidated
+    if !can_liquidate_loan(env, loan_id)? {
+        return Err(NFTError::LoanNotOverdue);
+    }
+
+    let mut loan_registry: LoanRegistry = env
+        .storage()
+        .instance()
+        .get(&LOAN_REGISTRY_KEY)
+        .ok_or(NFTError::LoanNotFound)?;
+    
+    let mut loan = loan_registry
+        .get_loan(loan_id)
+        .ok_or(NFTError::LoanNotFound)?;
+
+    // Get the NFT collateral
+    let mut nft_registry: NFTRegistry = env
+        .storage()
+        .instance()
+        .get(&NFT_REGISTRY_KEY)
+        .unwrap_or_else(|| NFTRegistry::new(env));
+    
+    let mut nft = nft_registry
+        .get_nft(loan.collection_id, loan.token_id)
+        .ok_or(NFTError::NFTNotFound)?;
+
+    // Calculate 5% liquidation bonus: liquidator gets NFT collateral minus 5% fee to protocol
+    // In a real implementation, this would be handled more gracefully, but for simulation:
+    // Liquidator receives the NFT, and must repay the loan plus 5% bonus
+    // This simulates the liquidator getting a 5% bonus on the collateral
+
+    // Mark loan as liquidated
+    loan.is_liquidated = true;
+    loan.is_active = false;
+    loan_registry.mark_liquidated(loan_id)?;
+    env.storage()
+        .instance()
+        .set(&LOAN_REGISTRY_KEY, &loan_registry);
+
+    // Transfer NFT ownership to liquidator
+    nft_registry.transfer_ownership(env, loan.collection_id, loan.token_id, liquidator.clone())?;
+    env.storage()
+        .instance()
+        .set(&NFT_REGISTRY_KEY, &nft_registry);
+
+    // Update pool's borrowed amount (loan is repaid through liquidation)
+    let mut pool_registry: LendingPoolRegistry = env
+        .storage()
+        .instance()
+        .get(&LENDING_POOL_REGISTRY_KEY)
+        .unwrap_or_else(|| LendingPoolRegistry::new(env));
+    
+    // Extract pool_id from lender address (simplified)
+    if let Ok(pool_id_str) = loan.lender.to_string().parse::<u64>() {
+        if let Some(mut pool) = pool_registry.get_pool(pool_id_str) {
+            pool.total_borrowed = pool.total_borrowed.checked_sub(loan.loan_amount).ok_or(NFTError::AmountOverflow)?;
+            pool_registry.update_pool(pool);
+            env.storage()
+                .instance()
+                .set(&LENDING_POOL_REGISTRY_KEY, &pool_registry);
+        }
+    }
+
+    // Update portfolios
+    decrement_portfolio_loans_taken(env, loan.borrower.clone())?;
+
+    // Update liquidator's portfolio
+    let mut portfolio_registry: Map<Address, NFTPortfolio> = env
+        .storage()
+        .instance()
+        .get(&PORTFOLIO_REGISTRY_KEY)
+        .unwrap_or_else(|| Map::new(env));
+    let mut portfolio = portfolio_registry
+        .get(liquidator.clone())
+        .unwrap_or_else(|| NFTPortfolio::new(env, liquidator.clone()));
+    portfolio.total_nfts_owned = portfolio.total_nfts_owned.saturating_add(1);
+    portfolio_registry.set(liquidator.clone(), portfolio);
+    env.storage()
+        .instance()
+        .set(&PORTFOLIO_REGISTRY_KEY, &portfolio_registry);
+
+    // Emit liquidation event with 5% bonus information
+    crate::nft_events::emit_loan_liquidated(
+        env,
+        loan_id,
+        liquidator,
+        loan.collection_id,
+        loan.token_id,
+    );
+    crate::nft_events::emit_liquidation_bonus(
+        env,
+        loan_id,
+        liquidator,
+        (nft.total_supply as i128 * LIQUIDATION_BONUS_BPS as i128 / 10000),
+    );
+
+    Ok(())
+}
+
+/// Repay a loan taken from a lending pool
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `borrower` - Loan borrower
+/// * `pool_id` - Lending pool ID
+/// * `loan_id` - Loan ID to repay
+/// * `repayment_amount` - Amount being repaid
+///
+/// # Returns
+/// * `Result<(), NFTError>` - Success or error
+pub fn repay_lending_pool_loan(
+    env: &Env,
+    borrower: Address,
+    pool_id: u64,
+    loan_id: u64,
+    repayment_amount: i128,
+) -> Result<(), NFTError> {
+    borrower.require_auth();
+
+    if is_marketplace_paused(env) {
+        return Err(NFTError::MarketplacePaused);
+    }
+
+    let mut loan_registry: LoanRegistry = env
+        .storage()
+        .instance()
+        .get(&LOAN_REGISTRY_KEY)
+        .ok_or(NFTError::LoanNotFound)?;
+    
+    let loan = loan_registry
+        .get_loan(loan_id)
+        .ok_or(NFTError::LoanNotFound)?;
+
+    // Verify borrower
+    if loan.borrower != borrower {
+        return Err(NFTError::Unauthorized);
+    }
+
+    // Check loan state
+    if !loan.is_active {
+        return Err(NFTError::LoanNotActive);
+    }
+    if loan.is_repaid {
+        return Err(NFTError::LoanAlreadyRepaid);
+    }
+    if loan.is_liquidated {
+        return Err(NFTError::LoanLiquidated);
+    }
+
+    // Calculate amount due
+    let current_time = env.ledger().timestamp();
+    let amount_due = loan.total_due(current_time);
+
+    if repayment_amount < amount_due {
+        return Err(NFTError::InsufficientRepayment);
+    }
+
+    // Mark loan as repaid
+    loan_registry.mark_repaid(loan_id)?;
+    env.storage()
+        .instance()
+        .set(&LOAN_REGISTRY_KEY, &loan_registry);
+
+    // Return NFT to borrower
+    let mut nft_registry: NFTRegistry = env
+        .storage()
+        .instance()
+        .get(&NFT_REGISTRY_KEY)
+        .unwrap_or_else(|| NFTRegistry::new(env));
+    // In this implementation, the NFT was only locked, not transferred, so we just confirm it's back to the borrower
+    // In production, you would transfer it back from the pool/escrow
+
+    // Update the lending pool
+    let mut pool_registry: LendingPoolRegistry = env
+        .storage()
+        .instance()
+        .get(&LENDING_POOL_REGISTRY_KEY)
+        .ok_or(NFTError::LoanNotFound)?;
+    
+    let mut pool = pool_registry
+        .get_pool(pool_id)
+        .ok_or(NFTError::LoanNotFound)?;
+
+    // Calculate interest that gets added to the pool for lenders
+    let interest = repayment_amount - loan.loan_amount;
+    pool.total_borrowed = pool.total_borrowed.checked_sub(loan.loan_amount).ok_or(NFTError::AmountOverflow)?;
+    // The principal is returned to available liquidity, interest is distributed to lenders
+    pool.total_deposited = pool.total_deposited.checked_add(interest).ok_or(NFTError::AmountOverflow)?;
+    pool_registry.update_pool(pool);
+    env.storage()
+        .instance()
+        .set(&LENDING_POOL_REGISTRY_KEY, &pool_registry);
+
+    // Update portfolios
+    decrement_portfolio_loans_taken(env, borrower)?;
+    decrement_portfolio_loans_given(env, loan.lender.clone())?;
+
+    // Emit repayment event
+    crate::nft_events::emit_loan_repaid(env, loan_id, borrower, repayment_amount);
 
     Ok(())
 }

--- a/swaptrade-contracts/counter/src/nft_storage.rs
+++ b/swaptrade-contracts/counter/src/nft_storage.rs
@@ -26,6 +26,186 @@ pub const FEE_RECIPIENT_KEY: Symbol = symbol_short!("fee_recv");
 pub const LIQUIDATION_QUEUE_KEY: Symbol = symbol_short!("liq_queue");
 pub const LIQUIDATION_BID_REGISTRY_KEY: Symbol = symbol_short!("liq_bid");
 
+// Lending pool storage keys
+pub const LENDING_POOL_REGISTRY_KEY: Symbol = symbol_short!("lpool_reg");
+pub const LENDER_DEPOSITS_KEY: Symbol = symbol_short!("lend_deps");
+
+/// Lending Pool Registry - stores all lending pools
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct LendingPoolRegistry {
+    /// Map of pool_id -> LendingPool
+    pub pools: Map<u64, LendingPool>,
+    /// Total pools created
+    pub total_pools: u64,
+}
+
+/// Individual Lending Pool
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct LendingPool {
+    pub pool_id: u64,
+    pub asset: Symbol, // The asset supplied to the pool (e.g., USDC)
+    pub total_deposited: i128,
+    pub total_borrowed: i128,
+    pub reserve_factor_bps: u32, // Protocol reserve fee
+    pub base_rate_bps: u32,      // Base interest rate
+    pub is_active: bool,
+    pub created_at: u64,
+}
+
+/// Lender Deposit - tracks individual lender deposits
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct LenderDeposit {
+    pub pool_id: u64,
+    pub lender: Address,
+    pub amount: i128,
+    pub shares: i128, // pTokens representing deposit shares
+    pub deposited_at: u64,
+}
+
+impl LendingPoolRegistry {
+    pub fn new(env: &Env) -> Self {
+        Self {
+            pools: Map::new(env),
+            total_pools: 0,
+        }
+    }
+
+    /// Get a pool by ID
+    pub fn get_pool(&self, pool_id: u64) -> Option<LendingPool> {
+        self.pools.get(pool_id)
+    }
+
+    /// Create a new pool
+    pub fn create_pool(&mut self, env: &Env, pool: LendingPool) -> u64 {
+        let pool_id = pool.pool_id;
+        self.pools.set(pool_id, pool);
+        self.total_pools = self.total_pools.saturating_add(1);
+        pool_id
+    }
+
+    /// Update a pool
+    pub fn update_pool(&mut self, pool: LendingPool) {
+        self.pools.set(pool.pool_id, pool);
+    }
+}
+
+/// Next pool ID generator
+pub fn get_next_pool_id(env: &Env) -> u64 {
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get(&Symbol::new(env, "next_pool"))
+        .unwrap_or(1);
+    env.storage()
+        .instance()
+        .set(&Symbol::new(env, "next_pool"), &(current + 1));
+    current
+}
+
+// ERC4626 Fractional Vault storage keys
+pub const FRACTIONAL_VAULT_REGISTRY_KEY: Symbol = symbol_short!("fv_reg");
+pub const VAULT_SHARES_KEY: Symbol = symbol_short!("v_shares");
+
+/// Fractional Vault Registry - stores all ERC4626-compliant vaults
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct FractionalVaultRegistry {
+    /// Map of vault_id -> FractionalVault
+    pub vaults: Map<u64, FractionalVault>,
+    /// Reverse map of (collection_id, token_id) -> vault_id for O(1) vault lookups by NFT
+    pub nft_to_vault: Map<(u64, u64), u64>,
+    /// Total vaults created
+    pub total_vaults: u64,
+}
+
+/// Individual Fractional Vault (ERC4626 compliant)
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FractionalVault {
+    pub vault_id: u64,
+    pub collection_id: u64,
+    pub token_id: u64,
+    pub asset: Symbol, // The underlying asset (the NFT)
+    pub share_symbol: Symbol, // Vault share token symbol (fNFT)
+    pub total_shares: u64,
+    pub total_assets: i128, // Total value of assets in the vault
+    pub share_supply: u64,
+    pub created_at: u64,
+    pub owner: Address,
+    pub is_active: bool,
+}
+
+/// Vault Share - tracks individual share holdings
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VaultShare {
+    pub vault_id: u64,
+    pub owner: Address,
+    pub shares: u64,
+    pub last_deposit: u64,
+}
+
+impl FractionalVaultRegistry {
+    pub fn new(env: &Env) -> Self {
+        Self {
+            vaults: Map::new(env),
+            nft_to_vault: Map::new(env),
+            total_vaults: 0,
+        }
+    }
+
+    /// Get a vault by ID
+    pub fn get_vault(&self, vault_id: u64) -> Option<FractionalVault> {
+        self.vaults.get(vault_id)
+    }
+
+    /// Get a vault by its NFT collection_id and token_id (O(1) lookup)
+    pub fn get_vault_by_nft(&self, collection_id: u64, token_id: u64) -> Option<FractionalVault> {
+        let nft_key = (collection_id, token_id);
+        let vault_id = self.nft_to_vault.get(nft_key)?;
+        self.vaults.get(vault_id)
+    }
+
+    /// Create a new vault
+    pub fn create_vault(&mut self, env: &Env, vault: FractionalVault) -> u64 {
+        let vault_id = vault.vault_id;
+        let nft_key = (vault.collection_id, vault.token_id);
+        self.vaults.set(vault_id, vault);
+        self.nft_to_vault.set(nft_key, vault_id);
+        self.total_vaults = self.total_vaults.saturating_add(1);
+        vault_id
+    }
+
+    /// Update a vault
+    pub fn update_vault(&mut self, vault: FractionalVault) {
+        self.vaults.set(vault.vault_id, vault);
+    }
+
+    /// Remove a vault from the registry (cleans up both maps)
+    pub fn remove_vault(&mut self, vault_id: u64, collection_id: u64, token_id: u64) {
+        self.vaults.remove(vault_id);
+        let nft_key = (collection_id, token_id);
+        self.nft_to_vault.remove(nft_key);
+        self.total_vaults = self.total_vaults.saturating_sub(1);
+    }
+}
+
+/// Next vault ID generator
+pub fn get_next_vault_id(env: &Env) -> u64 {
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get(&Symbol::new(env, "next_vault"))
+        .unwrap_or(1);
+    env.storage()
+        .instance()
+        .set(&Symbol::new(env, "next_vault"), &(current + 1));
+    current
+}
+
 /// Default platform fee in basis points (2.5%)
 pub const DEFAULT_PLATFORM_FEE_BPS: u32 = 250;
 

--- a/swaptrade-contracts/counter/src/nft_types.rs
+++ b/swaptrade-contracts/counter/src/nft_types.rs
@@ -1,5 +1,5 @@
 
-use soroban_sdk::{contracttype, symbol_short, Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Map, Symbol, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -53,4 +53,176 @@ pub fn get_nft_metadata(achievement: Achievement) -> NftMetadata {
             uri: symbol_short!("https://.../cs.json"),
         },
     }
+}
+
+/// NFT Standard enum
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum NFTStandard {
+    ERC721,
+    ERC1155,
+}
+
+/// Main NFT struct
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NFT {
+    pub collection_id: u64,
+    pub token_id: u64,
+    pub owner: Address,
+    pub standard: NFTStandard,
+    pub is_fractionalized: bool,
+    pub total_supply: u64,
+    pub circulating_supply: u64,
+    pub metadata_uri: Symbol,
+    pub created_at: u64,
+}
+
+/// NFT Collection struct
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NFTCollection {
+    pub collection_id: u64,
+    pub name: Symbol,
+    pub symbol: Symbol,
+    pub owner: Address,
+    pub total_supply: u64,
+    pub created_at: u64,
+}
+
+/// NFT Listing struct for marketplace
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NFTListing {
+    pub listing_id: u64,
+    pub collection_id: u64,
+    pub token_id: u64,
+    pub seller: Address,
+    pub price: i128,
+    pub is_active: bool,
+    pub created_at: u64,
+    /// Whether this is a fractional share listing
+    pub is_fractional: bool,
+    /// Number of fractional shares being listed (only used if is_fractional = true)
+    pub share_amount: u64,
+}
+
+/// NFT Offer/Bid struct
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NFTOffer {
+    pub offer_id: u64,
+    pub collection_id: u64,
+    pub token_id: u64,
+    pub buyer: Address,
+    pub price: i128,
+    pub is_active: bool,
+    pub created_at: u64,
+    /// Whether this is a fractional share offer
+    pub is_fractional: bool,
+    /// Number of fractional shares being bid on (only used if is_fractional = true)
+    pub share_amount: u64,
+}
+
+/// NFT Loan struct
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NFTLoan {
+    pub loan_id: u64,
+    pub collection_id: u64,
+    pub token_id: u64,
+    pub borrower: Address,
+    pub lender: Address,
+    pub loan_amount: i128,
+    pub interest_rate_bps: u32,
+    pub repayment_amount: i128,
+    pub start_time: u64,
+    pub duration: u64,
+    pub due_date: u64,
+    pub is_active: bool,
+    pub is_repaid: bool,
+    pub is_liquidated: bool,
+}
+
+impl NFTLoan {
+    /// Calculate total amount due at current timestamp
+    pub fn total_due(&self, current_time: u64) -> i128 {
+        if !self.is_active || self.is_repaid || self.is_liquidated {
+            return self.repayment_amount;
+        }
+        
+        // Calculate additional interest if overdue
+        if current_time > self.due_date {
+            let overdue_seconds = current_time - self.due_date;
+            let overdue_days = (overdue_seconds as f64 / 86400.0) as u32;
+            let daily_interest = (self.loan_amount as u128 * self.interest_rate_bps as u128 / 10000) as i128;
+            return self.repayment_amount + (daily_interest * overdue_days as i128);
+        }
+        self.repayment_amount
+    }
+}
+
+/// Fractional Share struct
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FractionalShare {
+    pub token_id: u64,
+    pub collection_id: u64,
+    pub shareholder: Address,
+    pub shares: u64,
+    pub total_shares: u64,
+    pub purchase_price: i128,
+    pub acquired_at: u64,
+}
+
+/// NFT Valuation struct for oracle pricing
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NFTValuation {
+    pub collection_id: u64,
+    pub token_id: u64,
+    pub floor_price: i128,
+    pub last_updated: u64,
+    pub oracle_verified: bool,
+}
+
+/// NFT Portfolio struct
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NFTPortfolio {
+    pub owner: Address,
+    pub active_loans: u64,
+    pub loans_given: u64,
+    pub total_nfts_owned: u64,
+    pub total_fractional_shares: u64,
+    pub created_at: u64,
+}
+
+impl NFTPortfolio {
+    pub fn new(env: &Env, owner: Address) -> Self {
+        Self {
+            owner,
+            active_loans: 0,
+            loans_given: 0,
+            total_nfts_owned: 0,
+            total_fractional_shares: 0,
+            created_at: env.ledger().timestamp(),
+        }
+    }
+}
+
+/// NFT Trade struct
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NFTTrade {
+    pub collection_id: u64,
+    pub token_id: u64,
+    pub buyer: Address,
+    pub seller: Address,
+    pub price: i128,
+    pub timestamp: u64,
+    /// Whether this was a fractional share trade
+    pub is_fractional: bool,
+    /// Number of shares traded (only if is_fractional = true)
+    pub share_amount: u64,
 }


### PR DESCRIPTION
Closes #244

Add reverse mapping (collection_id, token_id) -> vault_id to FractionalVaultRegistry
- Eliminates O(n) loop in get_vault_by_nft() for constant-time lookups
- Follows existing registry pattern used by NFTRegistry and ListingRegistry
- Adds proper cleanup of both maps when vaults are removed
- Maintains backward compatibility with existing ERC4626 functionality