### PR TITLE
Implement admin controls with pause/resume trading functionality

### DIFF
--- a/swaptrade-contracts/counter/src/admin_controls_test.rs
+++ b/swaptrade-contracts/counter/src/admin_controls_test.rs
@@ -1,0 +1,397 @@
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{symbol_short, Address, Env};
+
+#[test]
+fn test_set_admin_requires_admin() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let random_user = Address::generate(&env);
+
+    // Initialize admin
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+
+    // Non-admin user should fail to set admin
+    let result = client.try_set_admin(&random_user, &new_admin);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), SwapTradeError::NotAdmin);
+}
+
+#[test]
+fn test_set_admin_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    // Initialize admin
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+
+    // Admin can set new admin
+    client.set_admin(&admin, &new_admin);
+
+    // Verify admin changed
+    let stored_admin: Address = env.storage().persistent().get(&ADMIN_KEY).unwrap();
+    assert_eq!(stored_admin, new_admin);
+
+    // Verify event was emitted
+    let events = env.events().all();
+    assert!(events.len() > 0);
+    let last_event = events.get(events.len() - 1).unwrap();
+    assert_eq!(last_event.topic, (symbol_short!("AdminChanged"),));
+}
+
+#[test]
+fn test_pause_trading_requires_admin() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let random_user = Address::generate(&env);
+
+    // Initialize admin
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+
+    // Non-admin user should fail to pause trading
+    let result = client.try_pause_trading(&random_user);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), SwapTradeError::NotAdmin);
+}
+
+#[test]
+fn test_pause_trading_emits_event_and_sets_flag() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+
+    // Initialize admin
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+
+    // Admin can pause trading
+    let result = client.pause_trading(&admin);
+    assert!(result.unwrap());
+
+    // Verify paused flag is set
+    let paused: bool = env.storage().persistent().get(&PAUSED_KEY).unwrap_or(false);
+    assert!(paused);
+
+    // Verify event was emitted
+    let events = env.events().all();
+    assert!(events.len() > 0);
+    let last_event = events.get(events.len() - 1).unwrap();
+    assert_eq!(last_event.topic, (symbol_short!("AdminPaused"), admin));
+}
+
+#[test]
+fn test_resume_trading_requires_admin() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let random_user = Address::generate(&env);
+
+    // Initialize admin and pause trading
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+    env.storage()
+        .persistent()
+        .set(&PAUSED_KEY, &true);
+
+    // Non-admin user should fail to resume trading
+    let result = client.try_resume_trading(&random_user);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), SwapTradeError::NotAdmin);
+}
+
+#[test]
+fn test_resume_trading_emits_event_and_clears_flag() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+
+    // Initialize admin and pause trading
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+    env.storage()
+        .persistent()
+        .set(&PAUSED_KEY, &true);
+
+    // Admin can resume trading
+    let result = client.resume_trading(&admin);
+    assert!(result.unwrap());
+
+    // Verify paused flag is cleared
+    let paused: bool = env.storage().persistent().get(&PAUSED_KEY).unwrap_or(false);
+    assert!(!paused);
+
+    // Verify event was emitted
+    let events = env.events().all();
+    assert!(events.len() > 0);
+    let last_event = events.get(events.len() - 1).unwrap();
+    assert_eq!(last_event.topic, (symbol_short!("AdminResumed"), admin));
+}
+
+#[test]
+fn test_swap_rejects_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let xlm = symbol_short!("XLM");
+    let usdc = symbol_short!("USDCSIM");
+
+    // Initialize admin and pause trading
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+    env.storage()
+        .persistent()
+        .set(&PAUSED_KEY, &true);
+
+    // Mint tokens to user
+    client.mint(&xlm, &user, &1000);
+
+    // Swap should fail with TradingPaused error
+    let result = client.try_swap(&xlm, &usdc, &500, &user);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), ContractError::TradingPaused);
+}
+
+#[test]
+fn test_safe_swap_returns_zero_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let xlm = symbol_short!("XLM");
+    let usdc = symbol_short!("USDCSIM");
+
+    // Initialize admin and pause trading
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+    env.storage()
+        .persistent()
+        .set(&PAUSED_KEY, &true);
+
+    // Mint tokens to user
+    client.mint(&xlm, &user, &1000);
+
+    // safe_swap should return 0 when paused
+    let deadline = env.ledger().timestamp() + 1000;
+    let result = client.safe_swap(&xlm, &usdc, &500, &user, &deadline);
+    assert_eq!(result, 0);
+}
+
+#[test]
+fn test_add_liquidity_rejects_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let xlm = symbol_short!("XLM");
+    let usdc = symbol_short!("USDCSIM");
+
+    // Initialize admin and pause trading
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+    env.storage()
+        .persistent()
+        .set(&PAUSED_KEY, &true);
+
+    // Mint tokens to user
+    client.mint(&xlm, &user, &1000);
+    client.mint(&usdc, &user, &1000);
+
+    // add_liquidity should fail with TradingPaused error
+    let result = client.try_add_liquidity(&500, &500, &user);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), ContractError::TradingPaused);
+}
+
+#[test]
+fn test_remove_liquidity_rejects_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    // Initialize admin and pause trading
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+    env.storage()
+        .persistent()
+        .set(&PAUSED_KEY, &true);
+
+    // remove_liquidity should fail with TradingPaused error
+    let result = client.try_remove_liquidity(&100, &user);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), ContractError::TradingPaused);
+}
+
+#[test]
+fn test_pool_swap_rejects_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let xlm = symbol_short!("XLM");
+
+    // Initialize admin and pause trading
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+    env.storage()
+        .persistent()
+        .set(&PAUSED_KEY, &true);
+
+    // pool_swap should fail with TradingPaused error
+    let result = client.try_pool_swap(&1, &xlm, &100, &0, &trader);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), ContractError::TradingPaused);
+}
+
+#[test]
+fn test_execute_batch_atomic_rejects_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let xlm = symbol_short!("XLM");
+    let usdc = symbol_short!("USDCSIM");
+
+    // Initialize admin and pause trading
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+    env.storage()
+        .persistent()
+        .set(&PAUSED_KEY, &true);
+
+    // Create batch operation
+    let mut operations = Vec::new(&env);
+    operations.push_back(BatchOperation::Swap(xlm.clone(), usdc.clone(), 100, user.clone()));
+
+    // execute_batch_atomic should fail when paused
+    let result = client.execute_batch_atomic(operations);
+    assert_eq!(result.operations_failed, 1);
+}
+
+#[test]
+fn test_execute_batch_best_effort_rejects_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let xlm = symbol_short!("XLM");
+    let usdc = symbol_short!("USDCSIM");
+
+    // Initialize admin and pause trading
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+    env.storage()
+        .persistent()
+        .set(&PAUSED_KEY, &true);
+
+    // Create batch operation
+    let mut operations = Vec::new(&env);
+    operations.push_back(BatchOperation::Swap(xlm.clone(), usdc.clone(), 100, user.clone()));
+
+    // execute_batch_best_effort should fail when paused
+    let result = client.execute_batch_best_effort(operations);
+    assert_eq!(result.operations_failed, 1);
+}
+
+#[test]
+fn test_swap_succeeds_after_resume() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let xlm = symbol_short!("XLM");
+    let usdc = symbol_short!("USDCSIM");
+
+    // Initialize admin
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+
+    // Mint tokens to user
+    client.mint(&xlm, &user, &1000);
+
+    // Pause trading
+    client.pause_trading(&admin);
+
+    // Swap should fail
+    let result = client.try_swap(&xlm, &usdc, &500, &user);
+    assert!(result.is_err());
+
+    // Resume trading
+    client.resume_trading(&admin);
+
+    // Swap should succeed
+    let result = client.swap(&xlm, &usdc, &500, &user);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_set_treasury_requires_admin() {
+    let env = Env::default();
+    let contract_id = env.register(CounterContract, ());
+    let client = CounterContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_treasury = Address::generate(&env);
+    let random_user = Address::generate(&env);
+
+    // Initialize admin
+    env.storage()
+        .persistent()
+        .set(&ADMIN_KEY, &admin);
+
+    // Non-admin user should fail to set treasury
+    let result = client.try_set_treasury(&random_user, &new_treasury);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), SwapTradeError::NotAdmin);
+}

--- a/swaptrade-contracts/counter/src/events.rs
+++ b/swaptrade-contracts/counter/src/events.rs
@@ -141,6 +141,11 @@ impl Events {
             .publish((Symbol::new(env, "AdminResumed"), admin), (timestamp,));
     }
 
+    pub fn admin_changed(env: &Env, old_admin: Address, new_admin: Address, timestamp: i64) {
+        env.events()
+            .publish((Symbol::new(env, "AdminChanged"),), (old_admin, new_admin, timestamp));
+    }
+
     pub fn faucet_claimed(env: &Env, user: Address, asset: Symbol, amount: i128, timestamp: u64) {
         env.events().publish(
             (Symbol::new(env, "FaucetClaimed"), user, asset),

--- a/swaptrade-contracts/counter/src/lib.rs
+++ b/swaptrade-contracts/counter/src/lib.rs
@@ -53,6 +53,9 @@ mod orders;
 mod orders_tests;
 mod risk_management;
 
+#[cfg(test)]
+mod admin_controls_test;
+
 mod governance_system;
 
 #[cfg(test)]
@@ -189,6 +192,14 @@ fn require_authenticated_verified_user(env: &Env, user: &Address) -> Result<(), 
     require_verified_user(env, user)
 }
 
+fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+    let paused: bool = env.storage().persistent().get(&PAUSED_KEY).unwrap_or(false);
+    if paused {
+        return Err(ContractError::TradingPaused);
+    }
+    Ok(())
+}
+
 // pub fn pause_trading(env: Env, caller: Address) -> Result<bool, SwapTradeError> {
 //     caller.require_auth();
 //     crate::admin::require_admin(&env, &caller)?;
@@ -203,49 +214,6 @@ fn require_authenticated_verified_user(env: &Env, user: &Address) -> Result<(), 
 //     Ok(true)
 // }
 
-// pub fn set_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), SwapTradeError> {
-//     caller.require_auth();
-//     crate::admin::require_admin(&env, &caller)?;
-//     env.storage().persistent().set(&ADMIN_KEY, &new_admin);
-//     Ok(())
-// }
-
-// pub fn set_treasury(
-//     env: Env,
-//     caller: Address,
-//     new_treasury: Address,
-// ) -> Result<(), SwapTradeError> {
-//     caller.require_auth();
-//     crate::admin::require_admin(&env, &caller)?;
-//     env.storage()
-//         .persistent()
-//         .set(&crate::storage::DEFAULT_TREASURY_KEY, &new_treasury);
-//     crate::events::fee_parameters_updated(&env, 0, 0, Some(new_treasury));
-//     Ok(())
-// }
-
-pub fn pause_trading(env: Env) -> Result<bool, SwapTradeError> {
-    env.storage().persistent().set(&PAUSED_KEY, &true);
-    Ok(true)
-}
-
-pub fn resume_trading(env: Env) -> Result<bool, SwapTradeError> {
-    env.storage().persistent().set(&PAUSED_KEY, &false);
-    Ok(true)
-}
-
-pub fn set_admin(env: Env, new_admin: Address) -> Result<(), SwapTradeError> {
-    env.storage().persistent().set(&ADMIN_KEY, &new_admin);
-    Ok(())
-}
-
-pub fn set_treasury(env: Env, new_treasury: Address) -> Result<(), SwapTradeError> {
-    env.storage()
-        .persistent()
-        .set(&crate::storage::DEFAULT_TREASURY_KEY, &new_treasury);
-    crate::events::fee_parameters_updated(&env, 0, 0, Some(new_treasury));
-    Ok(())
-}
 
 pub fn create_proposal(
     env: Env,
@@ -464,6 +432,50 @@ impl CounterContract {
         migration::migrate_from_v1_to_v2(&env)
     }
 
+    /// Set the admin address (admin only)
+    pub fn set_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), SwapTradeError> {
+        caller.require_auth();
+        crate::admin::require_admin(&env, &caller)?;
+        
+        let old_admin = crate::admin::get_admin(&env);
+        env.storage().persistent().set(&ADMIN_KEY, &new_admin);
+        
+        crate::events::admin_changed(&env, old_admin, new_admin, env.ledger().timestamp());
+        Ok(())
+    }
+
+    /// Pause trading (admin only)
+    pub fn pause_trading(env: Env, caller: Address) -> Result<bool, SwapTradeError> {
+        caller.require_auth();
+        crate::admin::require_admin(&env, &caller)?;
+        
+        env.storage().persistent().set(&PAUSED_KEY, &true);
+        crate::events::admin_paused(&env, caller, env.ledger().timestamp());
+        Ok(true)
+    }
+
+    /// Resume trading (admin only)
+    pub fn resume_trading(env: Env, caller: Address) -> Result<bool, SwapTradeError> {
+        caller.require_auth();
+        crate::admin::require_admin(&env, &caller)?;
+        
+        env.storage().persistent().set(&PAUSED_KEY, &false);
+        crate::events::admin_resumed(&env, caller, env.ledger().timestamp());
+        Ok(true)
+    }
+
+    /// Set the treasury address (admin only)
+    pub fn set_treasury(env: Env, caller: Address, new_treasury: Address) -> Result<(), SwapTradeError> {
+        caller.require_auth();
+        crate::admin::require_admin(&env, &caller)?;
+        
+        env.storage()
+            .persistent()
+            .set(&crate::storage::DEFAULT_TREASURY_KEY, &new_treasury);
+        crate::events::fee_parameters_updated(&env, 0, 0, Some(new_treasury));
+        Ok(())
+    }
+
     pub fn mint(env: Env, token: Symbol, to: Address, amount: i128) {
         let mut portfolio: Portfolio = env
             .storage()
@@ -512,6 +524,7 @@ impl CounterContract {
         amount: i128,
         user: Address,
     ) -> Result<i128, ContractError> {
+        require_not_paused(&env)?;
         require_authenticated_verified_user(&env, &user)?;
 
         // Oracle validation
@@ -652,6 +665,9 @@ impl CounterContract {
     /// Non-panicking swap that counts failed orders and returns 0 on failure
     pub fn safe_swap(env: Env, from: Symbol, to: Symbol, amount: i128, user: Address, deadline: u64) -> i128 {
         if env.ledger().timestamp() > deadline {
+            return 0;
+        }
+        if require_not_paused(&env).is_err() {
             return 0;
         }
         if require_authenticated_verified_user(&env, &user).is_err() {
@@ -914,6 +930,13 @@ impl CounterContract {
     // ===== BATCH OPERATIONS =====
 
     pub fn execute_batch_atomic(env: Env, operations: Vec<BatchOperation>) -> BatchResult {
+        // Check if trading is paused
+        if require_not_paused(&env).is_err() {
+            let mut result = BatchResult::new(&env);
+            result.operations_failed = 1;
+            return result;
+        }
+
         // Validate batch operations are not empty
         if operations.is_empty() {
             let mut result = BatchResult::new(&env);
@@ -1000,6 +1023,13 @@ impl CounterContract {
     }
 
     pub fn execute_batch_best_effort(env: Env, operations: Vec<BatchOperation>) -> BatchResult {
+        // Check if trading is paused
+        if require_not_paused(&env).is_err() {
+            let mut result = BatchResult::new(&env);
+            result.operations_failed = 1;
+            return result;
+        }
+
         // Validate batch operations are not empty
         if operations.is_empty() {
             let mut result = BatchResult::new(&env);
@@ -1099,6 +1129,7 @@ impl CounterContract {
         usdc_amount: i128,
         user: Address,
     ) -> Result<i128, ContractError> {
+        require_not_paused(&env)?;
         require_authenticated_verified_user(&env, &user)?;
 
         if xlm_amount <= 0 || usdc_amount <= 0 {
@@ -1234,6 +1265,7 @@ impl CounterContract {
         lp_tokens: i128,
         user: Address,
     ) -> Result<(i128, i128), ContractError> {
+        require_not_paused(&env)?;
         require_authenticated_verified_user(&env, &user)?;
 
         if lp_tokens <= 0 {
@@ -1362,6 +1394,7 @@ impl CounterContract {
         amount_b: i128,
         provider: Address,
     ) -> Result<i128, ContractError> {
+        require_not_paused(&env)?;
         provider.require_auth();
         require_verified_user(&env, &provider)?;
 
@@ -1389,6 +1422,7 @@ impl CounterContract {
         lp_tokens: i128,
         provider: Address,
     ) -> Result<(i128, i128), ContractError> {
+        require_not_paused(&env)?;
         provider.require_auth();
         require_verified_user(&env, &provider)?;
 
@@ -1418,6 +1452,7 @@ impl CounterContract {
         min_amount_out: i128,
         trader: Address,
     ) -> Result<i128, ContractError> {
+        require_not_paused(&env)?;
         trader.require_auth();
         require_verified_user(&env, &trader)?;
 


### PR DESCRIPTION
- Move set_admin, pause_trading, resume_trading into #[contractimpl] block
- Add require_auth() checks to admin functions
- Add require_not_paused() check to trading functions (swap, safe_swap, add_liquidity, remove_liquidity, pool_swap, pool_add_liquidity, pool_remove_liquidity, batch operations)
- Add AdminChanged event to events.rs
- Emit AdminChanged, AdminPaused, AdminResumed events
- Add comprehensive integration tests for admin controls
- Ensure only admin can call admin functions with Unauthorized error
- Ensure trading operations reject with TradingPaused error when paused

closes #210